### PR TITLE
Version 1.5.2

### DIFF
--- a/TTPaymentsOTP.podspec
+++ b/TTPaymentsOTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TTPaymentsOTP'
-  s.version          = '1.5.1'
+  s.version          = '1.5.2'
   s.summary          = 'The Touchtech Payments iOS SDK, for integrating TouchTech Payments authentication into your iOS application.'
   s.description      = 'The TouchTech Payments iOS SDK, for integrating TouchTech Payments authentication into your iOS application. This SDK supports iOS 9 and above.'
 


### PR DESCRIPTION
Fixes bug on cardRegistration

Built for Swift 5.2.4 on XCode 11.5

Bump version to 1.5.2

**Note:** Due to some issues with Objective C interpreting generated header file. As a result this release still does not support Objective C