### PR TITLE
Version 1.6.1

### DIFF
--- a/TTPaymentsOTP.podspec
+++ b/TTPaymentsOTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TTPaymentsOTP'
-  s.version          = '1.5.2'
+  s.version          = '1.6.1'
   s.summary          = 'The Touchtech Payments iOS SDK, for integrating TouchTech Payments authentication into your iOS application.'
   s.description      = 'The TouchTech Payments iOS SDK, for integrating TouchTech Payments authentication into your iOS application. This SDK supports iOS 9 and above.'
 
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.source           = { :http => "https://github.com/Touch-Tech-Payments/3DS-iOS/releases/download/v#{s.version}/CocoaPods.tar.gz"}
   s.platform         = :ios
-  s.swift_version    = '5.2.4'
+  s.swift_version    = '5.3'
 
   s.dependency 'Starscream', '= 3.1.1'
 


### PR DESCRIPTION
Fixes bug on cardRegistration

Built for Swift 5.3 on XCode 12

Bump version to 1.6.1

**Note:** Due to some issues with Objective C interpreting generated header file. As a result this release still does not support Objective C